### PR TITLE
Fix `hasOwnProperty`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ function maskType(type, fn) {
 
   const fields = type.getFields();
   for (const fieldName in fields) {
-    if (!fields.hasOwnProperty(fieldName)) {
+    if (!Object.hasOwnProperty.call(fields, fieldName)) {
       continue;
     }
 
@@ -93,7 +93,7 @@ function maskType(type, fn) {
 function maskSchema(schema, fn) {
   const types = schema.getTypeMap();
   for (const typeName in types) {
-    if (!types.hasOwnProperty(typeName)) {
+    if (!Object.hasOwnProperty.call(types, typeName)) {
       continue;
     }
 


### PR DESCRIPTION
- fixes invalid call to `hasOwnProperty` on objects that don't have a prototype
