### PR TITLE
Pass resolver contextual information to error handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ function maskField(field, fn) {
       const out = resolveFn.call(this, ...args);
       return await Promise.resolve(out);
     } catch (e) {
-      throw fn(e);
+      throw fn(e, args);
     }
   };
 


### PR DESCRIPTION
I found it useful for my project, so you may want to consider to include this feature in your codebase.
It is very simple: it just passes the arguments received by the resolver, also to the error handler, in order to use that handler to report information of the context of the error such as the query executed (can be inferred in fourth argument's structure).