### PR TITLE
Allow to register custom user errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,10 @@ export const Processed = Symbol();
 export const IsUserError = Symbol();
 
 
+// Custom publicly exposable error constructors
+const customUserErrors = [];
+
+
 // UserErrors will be sent to the user
 export class UserError extends Error {
   constructor(...args) {
@@ -27,7 +31,7 @@ export class UserError extends Error {
 
 // Modifies errors before sending to the user
 export let defaultHandler = function (err) {
-  if (err[IsUserError]) {
+  if (err[IsUserError] || customUserErrors.some(e => err instanceof e)) {
     return err;
   }
   const errId = uuid.v4();
@@ -102,4 +106,13 @@ function maskSchema(schema, fn) {
 
     maskType(types[typeName], fn);
   }
+}
+
+
+export function addUserErrors (errors) {
+  errors.forEach(error => {
+    if (!customUserErrors.includes(error)) {
+      customUserErrors.push(error);
+    }
+  });
 }


### PR DESCRIPTION
Was needed a way to add custom user error constructor that is retrieved from a vendor package, so added a possibility to do so