### PR TITLE
Retain synchronicity of resolvers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ function maskField(field, fn) {
   field[Processed] = true;
   field.resolve = function (...args) {
     try {
-      const out = resolveFn.call(this, ...args);
+      let out = resolveFn.call(this, ...args);
       if (out && typeof out.then === 'function') {
         out = out.then(undefined, e => fn(e, args));
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,10 +63,13 @@ function maskField(field, fn) {
   }
 
   field[Processed] = true;
-  field.resolve = async function (...args) {
+  field.resolve = function (...args) {
     try {
       const out = resolveFn.call(this, ...args);
-      return await Promise.resolve(out);
+      if (typeof out.then === 'function') {
+        out = out.then(undefined, e => fn(e, args));
+      }
+      return out;
     } catch (e) {
       throw fn(e, args);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ function maskField(field, fn) {
   field.resolve = function (...args) {
     try {
       const out = resolveFn.call(this, ...args);
-      if (typeof out.then === 'function') {
+      if (out && typeof out.then === 'function') {
         out = out.then(undefined, e => fn(e, args));
       }
       return out;


### PR DESCRIPTION
Introspection queries should always resolve synchronously, and this wrapper causes them to be async. This causes problems when used in conjunction with Apollo.

This is a proposed fix, not actually tested. I used something similar for my wrappers.